### PR TITLE
refactor: update `getAllTasks` endpoint from `/tasks/all` to `/tasks`.

### DIFF
--- a/__tests__/services/task.service.all-tasks.test.ts
+++ b/__tests__/services/task.service.all-tasks.test.ts
@@ -12,15 +12,15 @@ describe('TaskService', () => {
   let taskService: TaskService;
   const baseUrl = 'https://vikunja.example.com/api/v1';
   const mockToken = 'mock-token';
-  
+
   beforeEach(() => {
     // Reset mocks before each test
     jest.resetAllMocks();
-    
+
     // Create a new service instance
     taskService = new TaskService(baseUrl, mockToken);
   });
-  
+
   describe('getAllTasks', () => {
     it('should fetch all tasks without parameters', async () => {
       // Mock tasks response
@@ -40,7 +40,7 @@ describe('TaskService', () => {
           done: true
         }
       ];
-      
+
       // Mock the fetch response
       const mockResponse = {
         ok: true,
@@ -51,19 +51,19 @@ describe('TaskService', () => {
           'content-type': 'application/json',
         })
       };
-      
+
       (global.fetch as jest.Mock).mockResolvedValue(mockResponse);
-      
+
       // Call the method
       const result = await taskService.getAllTasks();
-      
+
       // Verify the result
       expect(result).toEqual(mockTasks);
-      
+
       // Verify that fetch was called with the correct arguments
       expect(global.fetch).toHaveBeenCalledTimes(1);
       expect(global.fetch).toHaveBeenCalledWith(
-        `${baseUrl}/tasks/all`,
+        `${baseUrl}/tasks`,
         expect.objectContaining({
           method: 'GET',
           headers: expect.objectContaining({
@@ -85,7 +85,7 @@ describe('TaskService', () => {
           done: false
         }
       ];
-      
+
       const params = {
         page: 1,
         per_page: 10,
@@ -94,7 +94,7 @@ describe('TaskService', () => {
         order_by: 'asc' as 'asc' | 'desc',
         filter: 'done equals false'
       };
-      
+
       // Mock the fetch response
       const mockResponse = {
         ok: true,
@@ -105,23 +105,23 @@ describe('TaskService', () => {
           'content-type': 'application/json',
         })
       };
-      
+
       (global.fetch as jest.Mock).mockResolvedValue(mockResponse);
-      
+
       // Call the method
       const result = await taskService.getAllTasks(params);
-      
+
       // Verify the result
       expect(result).toEqual(mockTasks);
-      
+
       // Verify that fetch was called with the correct arguments including query params
       expect(global.fetch).toHaveBeenCalledTimes(1);
       expect(global.fetch).toHaveBeenCalledWith(
-        `${baseUrl}/tasks/all?page=1&per_page=10&s=search+term&sort_by=title&order_by=asc&filter=done+equals+false`,
+        `${baseUrl}/tasks?page=1&per_page=10&s=search+term&sort_by=title&order_by=asc&filter=done+equals+false`,
         expect.anything()
       );
     });
-    
+
     it('should handle multiple filter parameters', async () => {
       // Mock tasks response
       const mockTasks: Task[] = [
@@ -133,11 +133,11 @@ describe('TaskService', () => {
           priority: 1
         }
       ];
-      
+
       const params = {
         filter: 'done equals false and priority equals 1'
       };
-      
+
       // Mock the fetch response
       const mockResponse = {
         ok: true,
@@ -148,23 +148,23 @@ describe('TaskService', () => {
           'content-type': 'application/json',
         })
       };
-      
+
       (global.fetch as jest.Mock).mockResolvedValue(mockResponse);
-      
+
       // Call the method
       const result = await taskService.getAllTasks(params);
-      
+
       // Verify the result
       expect(result).toEqual(mockTasks);
-      
+
       // Verify that fetch was called with the correct arguments including query params
       expect(global.fetch).toHaveBeenCalledTimes(1);
       expect(global.fetch).toHaveBeenCalledWith(
-        `${baseUrl}/tasks/all?filter=done+equals+false+and+priority+equals+1`,
+        `${baseUrl}/tasks?filter=done+equals+false+and+priority+equals+1`,
         expect.anything()
       );
     });
-    
+
     it('should handle filter_include_nulls parameter', async () => {
       // Mock tasks response
       const mockTasks: Task[] = [
@@ -176,12 +176,12 @@ describe('TaskService', () => {
           due_date: ''
         }
       ];
-      
+
       const params = {
         filter: 'due_date equals ',
         filter_include_nulls: true
       };
-      
+
       // Mock the fetch response
       const mockResponse = {
         ok: true,
@@ -192,19 +192,19 @@ describe('TaskService', () => {
           'content-type': 'application/json',
         })
       };
-      
+
       (global.fetch as jest.Mock).mockResolvedValue(mockResponse);
-      
+
       // Call the method
       const result = await taskService.getAllTasks(params);
-      
+
       // Verify the result
       expect(result).toEqual(mockTasks);
-      
+
       // Verify that fetch was called with the correct arguments including query params
       expect(global.fetch).toHaveBeenCalledTimes(1);
       expect(global.fetch).toHaveBeenCalledWith(
-        `${baseUrl}/tasks/all?filter=due_date+equals+&filter_include_nulls=true`,
+        `${baseUrl}/tasks?filter=due_date+equals+&filter_include_nulls=true`,
         expect.anything()
       );
     });
@@ -216,7 +216,7 @@ describe('TaskService', () => {
         ok: false,
         status: 500,
         statusText: 'Internal Server Error',
-        json: jest.fn().mockResolvedValue({ 
+        json: jest.fn().mockResolvedValue({
           message: errorMessage,
           code: 500
         }),
@@ -224,9 +224,9 @@ describe('TaskService', () => {
           'content-type': 'application/json',
         })
       };
-      
+
       (global.fetch as jest.Mock).mockResolvedValue(mockResponse);
-      
+
       // Call the method and expect it to throw
       await expect(taskService.getAllTasks()).rejects.toThrow(VikunjaError);
       await expect(taskService.getAllTasks()).rejects.toMatchObject({
@@ -234,12 +234,12 @@ describe('TaskService', () => {
         statusCode: 500
       });
     });
-    
+
     it('should handle network errors', async () => {
       // Mock a network error
       const networkError = new Error('Network error');
       (global.fetch as jest.Mock).mockRejectedValue(networkError);
-      
+
       // Call the method and expect it to throw
       await expect(taskService.getAllTasks()).rejects.toThrow(VikunjaError);
       await expect(taskService.getAllTasks()).rejects.toMatchObject({
@@ -247,7 +247,7 @@ describe('TaskService', () => {
         statusCode: 0
       });
     });
-    
+
     it('should handle non-JSON responses', async () => {
       // Mock a response with non-JSON content
       const mockResponse = {
@@ -259,9 +259,9 @@ describe('TaskService', () => {
           'content-type': 'text/html',
         })
       };
-      
+
       (global.fetch as jest.Mock).mockResolvedValue(mockResponse);
-      
+
       // Call the method and expect it to throw
       await expect(taskService.getAllTasks()).rejects.toThrow(VikunjaError);
       await expect(taskService.getAllTasks()).rejects.toMatchObject({

--- a/src/services/task.service.ts
+++ b/src/services/task.service.ts
@@ -36,7 +36,7 @@ export class TaskService extends VikunjaService {
    * @returns List of tasks
    */
   async getAllTasks(params?: GetTasksParams): Promise<Task[]> {
-    return this.request<Task[]>('/tasks/all', 'GET', undefined, {
+    return this.request<Task[]>('/tasks', 'GET', undefined, {
       params: params as Record<string, string | number | boolean | undefined>,
     });
   }


### PR DESCRIPTION
## Description
This patch changes the API endpoint on getAllTasks from /tasks/all to /tasks, making it compatible with the currently released Vikunja version, solving "Invalid model provided: Bad Request" errors from Vikunja API.

## Related Issue
I'm unaware of an open issue related to this. To reproduce you need to use the getAllTaks method against a v1.1.0 Vikunja instance.

## Motivation and Context
Testing against Vikunja v1.1.0 I have noticed requests to /api/v1/tasks/all using vikunja-mcp. That returns {"code":2004,"message":"Invalid model provided: Bad Request"}. I have identified that /api/v1/tasks is returning the full list of tasks and could replace /api/v1/tasks/all (which is not in the current API documentation) and found out that vikunja-mcp uses this node-vikunja library for interacting with Vikunja, making this update necessary upstream.

## How Has This Been Tested?
I don't use node-viukunja directly (check [my fork of vikunja-mcp](https://github.com/autorz/vikunja-mcp)), so this was tested through vikunja-mcp. My agent started getting my list of tasks with this minimal change, producing the following logs:

```
vikunja-mcp        | 2026-02-15 20:38:12,817 - INFO - Calling endpoint: vikunja_tasks, with args: {'subcommand': 'list', 'allProjects': True}
vikunja-mcp        | [2026-02-15T20:38:12.820Z] [DEBUG] Executing tasks tool { subcommand: 'list', args: { subcommand: 'list', allProjects: true } }
vikunja-mcp        | [2026-02-15T20:38:12.821Z] [DEBUG] Starting task filtering orchestration {
vikunja-mcp        |   hasFilter: false,
vikunja-mcp        |   hasFilterId: false,
vikunja-mcp        |   projectId: undefined,
vikunja-mcp        |   page: undefined,
vikunja-mcp        |   perPage: undefined
vikunja-mcp        | }
vikunja-mcp        | [2026-02-15T20:38:12.821Z] [WARN] Task filtering validation warnings {
vikunja-mcp        |   warnings: [
vikunja-mcp        |     'Large page size (1000) may impact performance. Consider using smaller pages or more specific filters.'
vikunja-mcp        |   ]
vikunja-mcp        | }
vikunja-mcp        | [2026-02-15T20:38:12.823Z] [INFO] Applied default pagination for memory protection { per_page: 1000, page: 1 }
vikunja-mcp        | [2026-02-15T20:38:12.823Z] [INFO] Using client-side filtering { filter: undefined, endpoint: 'getAllTasks' }
vikunja            | time=2026-02-15T17:38:12.882-03:00 level=INFO component=http method=GET uri="/api/v1/tasks?per_page=1000&page=1" status=200 latency=54.995273ms
vikunja-mcp        | [2026-02-15T20:38:12.885Z] [INFO] Tasks loaded for client-side filtering { totalTasksLoaded: 50, filter: undefined }
vikunja-mcp        | [2026-02-15T20:38:12.885Z] [INFO] Memory usage for task listing {
vikunja-mcp        |   taskCount: 50,
vikunja-mcp        |   estimatedMemoryMB: 1,
vikunja-mcp        |   maxTasksLimit: 10000,
vikunja-mcp        |   utilizationPercent: 1
vikunja-mcp        | }
vikunja-mcp        | [2026-02-15T20:38:12.885Z] [DEBUG] Task filtering orchestration completed {
vikunja-mcp        |   taskCount: 50,
vikunja-mcp        |   serverSideFilteringUsed: false,
vikunja-mcp        |   clientSideFiltering: false
vikunja-mcp        | }
vikunja-mcp        | [2026-02-15T20:38:12.886Z] [DEBUG] Tasks tool response { subcommand: 'list', itemCount: 50 }
vikunja-mcp        | INFO:     172.20.2.1:41604 - "POST /vikunja_tasks HTTP/1.1" 200 OK
vikunja-mcp        | 2026-02-15 20:38:19,545 - INFO - Calling endpoint: vikunja_task_crud, with args: {'operation': 'list', 'allProjects': True}
vikunja-mcp        | [2026-02-15T20:38:19.548Z] [DEBUG] Executing task CRUD tool { operation: 'list', args: { operation: 'list', allProjects: true } }
vikunja-mcp        | [2026-02-15T20:38:19.549Z] [DEBUG] Starting task filtering orchestration {
vikunja-mcp        |   hasFilter: false,
vikunja-mcp        |   hasFilterId: false,
vikunja-mcp        |   projectId: undefined,
vikunja-mcp        |   page: undefined,
vikunja-mcp        |   perPage: undefined
vikunja-mcp        | }
vikunja-mcp        | [2026-02-15T20:38:19.549Z] [WARN] Task filtering validation warnings {
vikunja-mcp        |   warnings: [
vikunja-mcp        |     'Large page size (1000) may impact performance. Consider using smaller pages or more specific filters.'
vikunja-mcp        |   ]
vikunja-mcp        | }
vikunja-mcp        | [2026-02-15T20:38:19.550Z] [INFO] Applied default pagination for memory protection { per_page: 1000, page: 1 }
vikunja-mcp        | [2026-02-15T20:38:19.550Z] [INFO] Using client-side filtering { filter: undefined, endpoint: 'getAllTasks' }
vikunja            | time=2026-02-15T17:38:19.618-03:00 level=INFO component=http method=GET uri="/api/v1/tasks?per_page=1000&page=1" status=200 latency=65.759805ms
vikunja-mcp        | [2026-02-15T20:38:19.621Z] [INFO] Tasks loaded for client-side filtering { totalTasksLoaded: 50, filter: undefined }
vikunja-mcp        | [2026-02-15T20:38:19.621Z] [INFO] Memory usage for task listing {
vikunja-mcp        |   taskCount: 50,
vikunja-mcp        |   estimatedMemoryMB: 1,
vikunja-mcp        |   maxTasksLimit: 10000,
vikunja-mcp        |   utilizationPercent: 1
vikunja-mcp        | }
vikunja-mcp        | [2026-02-15T20:38:19.622Z] [DEBUG] Task filtering orchestration completed {
vikunja-mcp        |   taskCount: 50,
vikunja-mcp        |   serverSideFilteringUsed: false,
vikunja-mcp        |   clientSideFiltering: false
vikunja-mcp        | }
vikunja-mcp        | [2026-02-15T20:38:19.622Z] [DEBUG] Task CRUD tool response { operation: 'list', itemCount: 50 }
vikunja-mcp        | INFO:     172.20.2.1:54648 - "POST /vikunja_task_crud HTTP/1.1" 200 OK
vikunja            | time=2026-02-15T17:38:19.829-03:00 level=INFO component=http method=GET uri="/api/v1/notifications?page=1" status=200 latency=904.792µs
vikunja-mcp        | 2026-02-15 20:38:24,043 - INFO - Calling endpoint: vikunja_task_crud, with args: {'operation': 'list', 'perPage': 50.0, 'allProjects': True}
vikunja-mcp        | [2026-02-15T20:38:24.046Z] [DEBUG] Executing task CRUD tool {
vikunja-mcp        |   operation: 'list',
vikunja-mcp        |   args: { operation: 'list', perPage: 50, allProjects: true }
vikunja-mcp        | }
vikunja-mcp        | [2026-02-15T20:38:24.046Z] [DEBUG] Starting task filtering orchestration {
vikunja-mcp        |   hasFilter: false,
vikunja-mcp        |   hasFilterId: false,
vikunja-mcp        |   projectId: undefined,
vikunja-mcp        |   page: undefined,
vikunja-mcp        |   perPage: 50
vikunja-mcp        | }
vikunja-mcp        | [2026-02-15T20:38:24.046Z] [INFO] Using client-side filtering { filter: undefined, endpoint: 'getAllTasks' }
vikunja            | time=2026-02-15T17:38:24.110-03:00 level=INFO component=http method=GET uri="/api/v1/tasks?per_page=50" status=200 latency=60.792569ms
vikunja-mcp        | [2026-02-15T20:38:24.114Z] [INFO] Tasks loaded for client-side filtering { totalTasksLoaded: 50, filter: undefined }
vikunja-mcp        | [2026-02-15T20:38:24.114Z] [INFO] Memory usage for task listing {
vikunja-mcp        |   taskCount: 50,
vikunja-mcp        |   estimatedMemoryMB: 1,
vikunja-mcp        |   maxTasksLimit: 10000,
vikunja-mcp        |   utilizationPercent: 1
vikunja-mcp        | }
vikunja-mcp        | [2026-02-15T20:38:24.115Z] [DEBUG] Task filtering orchestration completed {
vikunja-mcp        |   taskCount: 50,
vikunja-mcp        |   serverSideFilteringUsed: false,
vikunja-mcp        |   clientSideFiltering: false
vikunja-mcp        | }
vikunja-mcp        | [2026-02-15T20:38:24.116Z] [DEBUG] Task CRUD tool response { operation: 'list', itemCount: 50 }
vikunja-mcp        | INFO:     172.20.2.1:54648 - "POST /vikunja_task_crud HTTP/1.1" 200 OK
vikunja            | time=2026-02-15T17:38:29.857-03:00 level=INFO component=http method=GET uri="/api/v1/notifications?page=1" status=200 latency=494.813µs
vikunja-mcp        | 2026-02-15 20:38:32,502 - INFO - Calling endpoint: vikunja_tasks, with args: {'subcommand': 'list', 'perPage': 100.0, 'sort': 'dueDate', 'allProjects': True}
vikunja-mcp        | [2026-02-15T20:38:32.503Z] [DEBUG] Executing tasks tool {
vikunja-mcp        |   subcommand: 'list',
vikunja-mcp        |   args: {
vikunja-mcp        |     subcommand: 'list',
vikunja-mcp        |     perPage: 100,
vikunja-mcp        |     sort: 'dueDate',
vikunja-mcp        |     allProjects: true
vikunja-mcp        |   }
vikunja-mcp        | }
vikunja-mcp        | [2026-02-15T20:38:32.504Z] [DEBUG] Starting task filtering orchestration {
vikunja-mcp        |   hasFilter: false,
vikunja-mcp        |   hasFilterId: false,
vikunja-mcp        |   projectId: undefined,
vikunja-mcp        |   page: undefined,
vikunja-mcp        |   perPage: 100
vikunja-mcp        | }
vikunja-mcp        | [2026-02-15T20:38:32.504Z] [INFO] Using client-side filtering { filter: undefined, endpoint: 'getAllTasks' }
vikunja            | time=2026-02-15T17:38:32.531-03:00 level=ERROR component=http method=GET uri="/api/v1/tasks?per_page=100&sort_by=dueDate" status=400 latency=24.971083ms err="Task Field is invalid [TaskField: dueDate]"
vikunja-mcp        | [2026-02-15T20:38:32.532Z] [ERROR] Task filtering execution error: {
vikunja-mcp        |   error: "The task field 'dueDate' is invalid.",
vikunja-mcp        |   params: { per_page: 100, sort_by: 'dueDate' },
vikunja-mcp        |   filter: undefined,
vikunja-mcp        |   filterId: undefined
vikunja-mcp        | }
vikunja-mcp        | [2026-02-15T20:38:32.533Z] [ERROR] Task filtering orchestration failed {
vikunja-mcp        |   error: "The task field 'dueDate' is invalid.",
vikunja-mcp        |   args: { hasFilter: false, hasFilterId: false, projectId: undefined }
vikunja-mcp        | }
vikunja-mcp        | [2026-02-15T20:38:32.533Z] [ERROR] Task list error: {
vikunja-mcp        |   error: "The task field 'dueDate' is invalid.",
vikunja-mcp        |   filter: undefined,
vikunja-mcp        |   filterId: undefined
vikunja-mcp        | }
vikunja-mcp        | 2026-02-15 20:38:32,536 - INFO - Unexpected error calling vikunja_tasks: Traceback (most recent call last):
vikunja-mcp        | INFO:     172.20.2.1:56570 - "POST /vikunja_tasks HTTP/1.1" 500 Internal Server Error
vikunja-mcp        |   File "/app/.venv/lib/python3.12/site-packages/mcpo/utils/main.py", line 328, in tool
vikunja-mcp        |     raise HTTPException(
vikunja-mcp        | fastapi.exceptions.HTTPException: 500: {'message': "Failed to list tasks: The task field 'dueDate' is invalid."}
vikunja-mcp        | 
vikunja-mcp        | 2026-02-15 20:38:35,350 - INFO - Calling endpoint: vikunja_tasks, with args: {'subcommand': 'list', 'perPage': 100.0, 'allProjects': True}
vikunja-mcp        | [2026-02-15T20:38:35.352Z] [DEBUG] Executing tasks tool {
vikunja-mcp        |   subcommand: 'list',
vikunja-mcp        |   args: { subcommand: 'list', perPage: 100, allProjects: true }
vikunja-mcp        | }
vikunja-mcp        | [2026-02-15T20:38:35.352Z] [DEBUG] Starting task filtering orchestration {
vikunja-mcp        |   hasFilter: false,
vikunja-mcp        |   hasFilterId: false,
vikunja-mcp        |   projectId: undefined,
vikunja-mcp        |   page: undefined,
vikunja-mcp        |   perPage: 100
vikunja-mcp        | }
vikunja-mcp        | [2026-02-15T20:38:35.352Z] [INFO] Using client-side filtering { filter: undefined, endpoint: 'getAllTasks' }
vikunja            | time=2026-02-15T17:38:35.383-03:00 level=INFO component=http method=GET uri="/api/v1/tasks?per_page=100" status=200 latency=29.880567ms
vikunja-mcp        | [2026-02-15T20:38:35.384Z] [INFO] Tasks loaded for client-side filtering { totalTasksLoaded: 50, filter: undefined }
vikunja-mcp        | [2026-02-15T20:38:35.384Z] [INFO] Memory usage for task listing {
vikunja-mcp        |   taskCount: 50,
vikunja-mcp        |   estimatedMemoryMB: 1,
vikunja-mcp        |   maxTasksLimit: 10000,
vikunja-mcp        |   utilizationPercent: 1
vikunja-mcp        | }
vikunja-mcp        | [2026-02-15T20:38:35.384Z] [DEBUG] Task filtering orchestration completed {
vikunja-mcp        |   taskCount: 50,
vikunja-mcp        |   serverSideFilteringUsed: false,
vikunja-mcp        |   clientSideFiltering: false
vikunja-mcp        | }
vikunja-mcp        | [2026-02-15T20:38:35.386Z] [DEBUG] Tasks tool response { subcommand: 'list', itemCount: 50 }
vikunja-mcp        | INFO:     172.20.2.1:56570 - "POST /vikunja_tasks HTTP/1.1" 200 OK
```


## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactor
- [ ] Performance improvement

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


Side-note: As can be observed in the logs, pagination is ignoring the per_page argument as used by node-vikunja, always returning 50 tasks per page. I haven't attempted fixing this yet, so I don't have more information.